### PR TITLE
Create connect credentials template file

### DIFF
--- a/assets/templates/.connect-credentials
+++ b/assets/templates/.connect-credentials
@@ -1,0 +1,2 @@
+url = 'https://pub.ferryland.posit.team/'
+key = 'xxx'

--- a/init.sh
+++ b/init.sh
@@ -20,6 +20,9 @@ echo "" >> ~/.bashrc && echo "" >> ~/.bashrc
 cat assets/templates/.bashrc >> ~/.bashrc
 echo "" >> ~/.bashrc && echo "" >> ~/.bashrc
 
+# Copy Connect Credentials dotfile template
+cp assets/templates/.connect-credentials ~/.connect-credentials
+
 # Install starship for a better terminal
 heading "Installing starship"
 wget --no-verbose --directory-prefix '/tmp' https://github.com/starship/starship/releases/download/v1.20.1/starship-x86_64-unknown-linux-musl.tar.gz \


### PR DESCRIPTION
Over in the [Posit Publisher](https://github.com/posit-dev/publisher) we got environment variables working, but when we tested support in Posit Workbench we noticed that the `.bashrc` exports were getting detecting by the Posit Publisher extension process.

To enable persistent credential support in Workbench for Posit Conf 2024 we shifted to supporting a `~/.connect-credentials` file where a single URL and API Key can be specified similar to `CONNECT_SERVER` and `CONNECT_API_KEY`.

This PR introduces a template `.connect-credentials` file for easier onboarding for the workshop.

More about the issue can be read about here: https://github.com/posit-dev/publisher/issues/2088